### PR TITLE
feat: allow for custom req headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ const getAbility = async (loggedInUser) => {
 };
 ```
 
+#### Custom request headers
+
+If needed, the SDK allows you to pass custom headers to the backend. This can be useful for passing authentication tokens or other necessary information.
+
+```javascript
+const permit = Permit({
+  loggedInUser: loggedInUser,
+  backendUrl: '/api/your-endpoint',
+  customRequestHeaders: {
+    Authorization: 'Bearer your-token',
+  });
+```
+
 ### Understanding Access Control Models with `loadLocalStateBulk`
 
 When working with access control in your application, it's crucial to understand the differences between various policy models: Role-Based Access Control (RBAC), Attribute-Based Access Control (ABAC), and Relationship-Based Access Control (ReBAC). Each of these models has its own way of determining permissions, which affects how you should configure and pass data to the loadLocalStateBulk function in your application.

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,24 +1,38 @@
-import axios from 'axios';
+import axios, { AxiosRequestHeaders } from 'axios';
 import { ActionResourceSchema, ReBACResourceSchema } from './types';
 import { permitState } from '.';
 
-export const getBulkPermissionFromBE = async (url: string, user: string, actionsResourcesList: ActionResourceSchema[]): Promise<boolean[]> => {
+export const getBulkPermissionFromBE = async (
+  url: string,
+  user: string,
+  actionsResourcesList: ActionResourceSchema[],
+  headers?: AxiosRequestHeaders,
+): Promise<boolean[]> => {
   const payload = actionsResourcesList.map((actionResource) => ({
     action: actionResource.action,
     resource: typeof actionResource.resource === 'string' ? actionResource.resource : `${actionResource.resource.type}:${actionResource.resource.key}`,
     resourceAttributes: actionResource.resourceAttributes || {},
   }));
-  
-  return await axios.post(`${url}?user=${user}`, { resourcesAndActions: payload }).then((response) => {
+
+  const config = headers ? { headers } : {};
+  return await axios.post(`${url}?user=${user}`, { resourcesAndActions: payload }, config).then((response) => {
     return response.data;
   });
 };
 
-export const getPermissionFromBE = async (url: string, user: string, action: string, resource: string | ReBACResourceSchema, defaultPermission: boolean): Promise<boolean> => {
+export const getPermissionFromBE = async (
+  url: string,
+  user: string,
+  action: string,
+  resource: string | ReBACResourceSchema,
+  defaultPermission: boolean,
+  headers?: AxiosRequestHeaders,
+): Promise<boolean> => {
   const resourceKey = typeof resource === 'string' ? resource : `${resource.type}:${resource.key}`;
-  
+  const config = headers ? { headers } : {};
+
   return await axios
-    .get(`${url}?user=${user}&action=${action}&resource=${resourceKey}`)
+    .get(`${url}?user=${user}&action=${action}&resource=${resourceKey}`, config)
     .then((response) => {
       return response.data.permitted;
     })


### PR DESCRIPTION
## Summary

Allow for custom request headers to be set. This allows consumers of the package to set custom headers on outbound requests. This can be useful for passing authentication tokens or other necessary information.

`customRequestHeaders` is an optional field, and if left empty it there will be changes to the default headers set by Axios.

```javascript
const permit = Permit({
  loggedInUser: loggedInUser,
  backendUrl: '/api/your-endpoint',
  customRequestHeaders: {
    Authorization: 'Bearer your-token',
  });
```

## How to test

1. Spin up the demo server
2. Init an instance of Permit with custom headers set
3. See that the headers are forward to the demo server
4. Init a new instance without custom headers set
5. See that the headers only contains the default Axios headers.