### PR TITLE
feat: add POST method support for single permission checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ export interface PermitCheckSchema {
   addKeyToState: (
     action: string,
     resource: string | ReBACResourceSchema,
-    userAttributes?: Record<string, any>,
     resourceAttributes?: Record<string, any>,
     method?: HttpMethod,
   ) => Promise<void>;
@@ -116,9 +115,9 @@ const getPermissionFromBE = async (
   defaultPermission: boolean,
   headers?: AxiosRequestHeaders,
   axiosConfig?: AxiosRequestConfig,
-  method: HttpMethod = 'GET',
-  userAttributes: Record<string, any> = {},
-  resourceAttributes: Record<string, any> = {},
+  method?: HttpMethod,
+  userAttributes?: Record<string, any>,
+  resourceAttributes?: Record<string, any>,
 ): Promise<boolean> => {
   // Exclude headers from axiosConfig for past compatibility.
   const { headers: _, ...restAxiosConfig } = axiosConfig ?? {};
@@ -131,8 +130,8 @@ const getPermissionFromBE = async (
     const payload = {
       action,
       resource,
-      userAttributes,
-      resourceAttributes,
+      userAttributes: userAttributes ?? {},
+      resourceAttributes: resourceAttributes ?? {},
     };
     try {
       const response = await axios.post(`${url}?user=${user}`, payload, config);
@@ -272,15 +271,12 @@ export const Permit = ({ loggedInUser, userAttributes = {}, backendUrl, defaultA
     return permitLocalState[key] ?? defaultAnswerIfNotExist;
   };
 
-  /* tslint:disable:no-shadowed-variable */
   const addKeyToState = async (
     action: string,
     resource: string | ReBACResourceSchema,
-    userAttributes?: Record<string, any>,
     resourceAttributes?: Record<string, any>,
-    method: HttpMethod = 'GET',
+    method?: HttpMethod,
   ) => {
-    /* tslint:enable:no-shadowed-variable */
     const resourceKey = typeof resource === 'string' ? resource : `${resource.type}:${resource.key}`;
     const permission = await getPermissionFromBE(
       backendUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export interface PermitCheckSchema {
     action: string,
     resource: string | ReBACResourceSchema,
     resourceAttributes?: Record<string, any>,
+    userAttributes?: Record<string, any>,
     method?: HttpMethod,
   ) => Promise<void>;
   loadLocalState: (actionsResourcesList: ActionResourceSchema[], method?: HttpMethod) => Promise<void>;
@@ -275,9 +276,12 @@ export const Permit = ({ loggedInUser, userAttributes = {}, backendUrl, defaultA
     action: string,
     resource: string | ReBACResourceSchema,
     resourceAttributes?: Record<string, any>,
+    userAttributesParam?: Record<string, any>,
     method?: HttpMethod,
   ) => {
     const resourceKey = typeof resource === 'string' ? resource : `${resource.type}:${resource.key}`;
+    // Allow overwrite by addKeyToState.
+    const finalUserAttributes = userAttributesParam ?? userAttributes;
     const permission = await getPermissionFromBE(
       backendUrl,
       loggedInUser,
@@ -287,10 +291,10 @@ export const Permit = ({ loggedInUser, userAttributes = {}, backendUrl, defaultA
       customRequestHeaders,
       axiosConfig,
       method,
-      userAttributes,
+      finalUserAttributes,
       resourceAttributes,
     );
-    await updatePermissionState({ action, resource, userAttributes, resourceAttributes }, permission);
+    await updatePermissionState({ action, resource, userAttributes: finalUserAttributes, resourceAttributes }, permission);
   };
 
   const reset = () => {

--- a/src/tests/Permit.test.ts
+++ b/src/tests/Permit.test.ts
@@ -84,10 +84,11 @@ describe('Permit Factory - POST Method Support', () => {
       const permit = Permit({
         loggedInUser: 'user1',
         backendUrl: 'http://example.com',
+        userAttributes: { department: 'Engineering' },
       });
 
       permit.reset();
-      await permit.addKeyToState('read', 'file', { department: 'Engineering' }, { country: 'PL' }, 'POST');
+      await permit.addKeyToState('read', 'file', { country: 'PL' }, 'POST');
 
       expect(mockedAxios.post).toHaveBeenCalledWith(
         'http://example.com?user=user1',

--- a/src/tests/Permit.test.ts
+++ b/src/tests/Permit.test.ts
@@ -19,6 +19,7 @@ describe('Permit Factory - POST Method Support', () => {
         backendUrl: 'http://example.com',
       });
 
+      permit.reset();
       await permit.loadLocalState(
         [
           {
@@ -52,6 +53,7 @@ describe('Permit Factory - POST Method Support', () => {
         backendUrl: 'http://example.com',
       });
 
+      permit.reset();
       await permit.loadLocalState([{ action: 'read', resource: 'file' }], 'POST');
 
       expect(permit.check('read', 'file', {})).toBe(false);
@@ -67,6 +69,7 @@ describe('Permit Factory - POST Method Support', () => {
         defaultAnswerIfNotExist: true,
       });
 
+      permit.reset();
       await permit.loadLocalState([{ action: 'read', resource: 'file' }], 'POST');
 
       expect(permit.check('read', 'file', {})).toBe(true);

--- a/src/tests/Permit.test.ts
+++ b/src/tests/Permit.test.ts
@@ -88,7 +88,7 @@ describe('Permit Factory - POST Method Support', () => {
       });
 
       permit.reset();
-      await permit.addKeyToState('read', 'file', { country: 'PL' }, 'POST');
+      await permit.addKeyToState('read', 'file', { country: 'PL' }, { department: 'Engineering' }, 'POST');
 
       expect(mockedAxios.post).toHaveBeenCalledWith(
         'http://example.com?user=user1',

--- a/src/tests/Permit.test.ts
+++ b/src/tests/Permit.test.ts
@@ -1,0 +1,102 @@
+import axios from 'axios';
+import { Permit } from '..';
+
+// Mock the axios module
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('Permit Factory - POST Method Support', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('loadLocalState with POST method', () => {
+    it('should send POST request with userAttributes and resourceAttributes in body', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: { permitted: true } });
+
+      const permit = Permit({
+        loggedInUser: 'user1',
+        backendUrl: 'http://example.com',
+      });
+
+      await permit.loadLocalState(
+        [
+          {
+            action: 'read',
+            resource: 'file',
+            userAttributes: { department: 'Engineering' },
+            resourceAttributes: { country: 'PL' },
+          },
+        ],
+        'POST',
+      );
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://example.com?user=user1',
+        {
+          action: 'read',
+          resource: 'file',
+          userAttributes: { department: 'Engineering' },
+          resourceAttributes: { country: 'PL' },
+        },
+        { headers: {} },
+      );
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+
+    it('should handle 403 error and return false', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 403 } });
+
+      const permit = Permit({
+        loggedInUser: 'user1',
+        backendUrl: 'http://example.com',
+      });
+
+      await permit.loadLocalState([{ action: 'read', resource: 'file' }], 'POST');
+
+      expect(permit.check('read', 'file', {})).toBe(false);
+    });
+
+    it('should handle other errors and return default permission', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 500 } });
+
+      const permit = Permit({
+        loggedInUser: 'user1',
+        backendUrl: 'http://example.com',
+        defaultAnswerIfNotExist: true,
+      });
+
+      await permit.loadLocalState([{ action: 'read', resource: 'file' }], 'POST');
+
+      expect(permit.check('read', 'file', {})).toBe(true);
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('addKeyToState with POST method', () => {
+    it('should send POST request with userAttributes and resourceAttributes in body', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: { permitted: true } });
+
+      const permit = Permit({
+        loggedInUser: 'user1',
+        backendUrl: 'http://example.com',
+      });
+
+      permit.reset();
+      await permit.addKeyToState('read', 'file', { department: 'Engineering' }, { country: 'PL' }, 'POST');
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://example.com?user=user1',
+        {
+          action: 'read',
+          resource: 'file',
+          userAttributes: { department: 'Engineering' },
+          resourceAttributes: { country: 'PL' },
+        },
+        { headers: {} },
+      );
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
1.  Add optional `method: 'GET' | 'POST'` parameter to `loadLocalState` and
   `addKeyToState` functions, defaulting to GET for backward compatibility.

2.   When POST is used, `userAttributes` and `resourceAttributes` are sent in
     the request body, enabling ABAC support for single permission checks
     (consistent with `loadLocalStateBulk` behavior)